### PR TITLE
Sort default Groups and Admins

### DIFF
--- a/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -95,7 +95,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
                 $groupDefaults[$resolvedGroupName]['items'][] = array(
                     'admin'        => $id,
-                    'label'        => '',
+                    'label'        => !empty($attributes['label']) ? $attributes['label'] : '',
                     'route'        => '',
                     'route_params' => array()
                 );
@@ -140,6 +140,26 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     $groups[$resolvedGroupName]['roles'] = $groupDefaults[$resolvedGroupName]['roles'];
                 }
             }
+        } elseif ($container->getParameter('sonata.admin.configuration.admins_sort')) {
+            $groups = $groupDefaults;
+
+            // sort the default group definition
+            ksort($groups);
+            array_walk(
+                $groups,
+                function (&$element) {
+                    usort(
+                        $element['items'],
+                        function ($a, $b) {
+                            if ($a['label'] === $b['label']) {
+                                return 0;
+                            }
+
+                            return $a['label'] < $b['label']?-1:1;
+                        }
+                    );
+                }
+            );
         } else {
             $groups = $groupDefaults;
         }
@@ -304,7 +324,6 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     || $definedTemplates['pager_results'] === 'SonataAdminBundle:Pager:results.html.twig'
                 )
             ) {
-
                 $definedTemplates['pager_results'] = 'SonataAdminBundle:Pager:simple_pager_results.html.twig';
             }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -76,6 +76,7 @@ class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('html5_validate')->defaultValue(true)->end()
+                        ->booleanNode('admins_sort')->defaultFalse()->end()
                         ->booleanNode('confirm_exit')->defaultValue(true)->end()
                         ->booleanNode('use_select2')->defaultValue(true)->end()
                         ->booleanNode('use_icheck')->defaultValue(true)->end()

--- a/DependencyInjection/SonataAdminExtension.php
+++ b/DependencyInjection/SonataAdminExtension.php
@@ -89,6 +89,7 @@ BOOM
         $container->setParameter('sonata.admin.configuration.admin_services', $config['admin_services']);
         $container->setParameter('sonata.admin.configuration.dashboard_groups', $config['dashboard']['groups']);
         $container->setParameter('sonata.admin.configuration.dashboard_blocks', $config['dashboard']['blocks']);
+        $container->setParameter('sonata.admin.configuration.admins_sort', $config['options']['admins_sort']);
 
         if (null === $config['security']['acl_user_manager'] && isset($bundles['FOSUserBundle'])) {
             $container->setParameter('sonata.admin.security.acl_user_manager', 'fos_user.user_manager');

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -57,6 +57,7 @@ Full Configuration Options
             title_logo:           bundles/sonataadmin/logo_title.png
             options:
                 html5_validate:       true
+                admins_sort:          false
                 confirm_exit:         true
                 use_select2:          true
                 use_icheck:           true

--- a/Resources/doc/reference/dashboard.rst
+++ b/Resources/doc/reference/dashboard.rst
@@ -50,6 +50,8 @@ Configuring the ``Admin`` list
 
 As you probably noticed by now, the ``Admin`` list groups ``Admin`` mappings together.
 There are several ways in which you can configure these groups.
+The order of all admins is when you defined them. To get a natural sorting add the option
+admins_sort: true.
 
 Using the ``Admin`` service declaration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Sorts all admins and groups regardless of their order in configuration. (https://github.com/sonata-project/SonataAdminBundle/issues/3018)

to activate you have to set the config option admins_sort to true
- `<tag name="sonata.admin" group="Z-Group" label="A-Admin"/>`
- `<tag name="sonata.admin" group="Y-Group" label="C-Admin"/>`
- `<tag name="sonata.admin" group="Y-Group" label="B-Admin"/>`

would result in the following order:
- Y-Group:
  - B-Admin
  - C-Admin
- Z-Group:
  - A-Admin
