### PR TITLE
Fix for AdminHelper to also support under_score model properties

### DIFF
--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -69,6 +69,34 @@ class AdminHelper
     }
 
     /**
+     *
+     * @param Symfony\Component\Form\FormBuilder $formBuilder
+     * @param string $elementId
+     *
+     * @return array
+     */
+    private function generateElementId(FormBuilder $formBuilder, $elementId)
+    {
+        $nameBase = $formBuilder->getName();
+        $elementId = $nameBase."_".$elementId;
+        foreach (new FormBuilderIterator($formBuilder) as $name => $formBuilder) {
+            $nameClean = substr($name, strlen($nameBase)+1);
+            if(strpos($elementId, $name) === 0) {
+                if(strlen($name) == strlen($elementId)) {
+                    return array($nameClean);
+                }
+                return array_merge(
+                    array($nameClean), 
+                    $this->generateElementId(
+                        $formBuilder,
+                        substr($elementId, strlen($name)+1)
+                    )
+                );
+            }
+        }
+    }
+
+    /**
      * Note:
      *   This code is ugly, but there is no better way of doing it.
      *   For now the append form element action used to add a new row works
@@ -91,8 +119,8 @@ class AdminHelper
         $form->setData($subject);
         $form->handleRequest($admin->getRequest());
 
-        $elementId = preg_replace('#.(\d+)#', '[$1]', implode('.', explode('_', substr($elementId, strpos($elementId, '_') + 1))));
-
+        $elementId = preg_replace('#.(\d+)#', '[$1]', implode('.',$this->generateElementId($formBuilder, substr($elementId, strpos($elementId, '_') + 1))));
+        
         // append a new instance into the object
         $this->addNewInstance($admin, $elementId);
 

--- a/Admin/AdminHelper.php
+++ b/Admin/AdminHelper.php
@@ -148,11 +148,8 @@ class AdminHelper
 
         $collection = $propertyAccessor->getValue($entity, $elementId);
 
-        if ($collection instanceof \Doctrine\ORM\PersistentCollection || $collection instanceof \Doctrine\ODM\MongoDB\PersistentCollection) {
-            //since doctrine 2.4
-            $entityClassName = $collection->getTypeClass()->getName();
-        } elseif ($collection instanceof \Doctrine\Common\Collections\Collection) {
-            $entityClassName = $this->entityClassNameFinder($admin, explode('.', preg_replace('#\[\d*?\]#', '', $elementId)));
+        if ($collection instanceof \Doctrine\Common\Collections\Collection || $collection instanceof \Doctrine\ORM\PersistentCollection || $collection instanceof \Doctrine\ODM\MongoDB\PersistentCollection) {
+            $instance = $this->getClassInstance($admin, explode('.', preg_replace('#\[\d*?\]#', '', $elementId)));
         } else {
             return;
         }
@@ -161,24 +158,23 @@ class AdminHelper
             return;
         }
 
-        $collection->add(new $entityClassName);
+        $collection->add($instance);
 
         $propertyAccessor->setValue($entity, $elementId, $collection);
     }
 
-
-    protected function entityClassNameFinder(AdminInterface $admin, $elements)
+    protected function getClassInstance(AdminInterface $admin, $elements)
     {
         $element = array_shift($elements);
 
         $associationAdmin = $admin->getFormFieldDescription($element)->getAssociationAdmin();
 
         if (count($elements) == 0) {
-            return $associationAdmin->getClass();
+            return $associationAdmin->getNewInstance();
         } else {
-            return $this->entityClassNameFinder($associationAdmin, $elements);
+            return $this->getClassInstance($associationAdmin, $elements);
         }
-    }
+     }
 
     /**
      * Camelize a string


### PR DESCRIPTION
This fixes a bug where your current AdminHelper would try to access under_score Model properties like
$valuable_reviews using getValuable() or getReviews().
